### PR TITLE
Add minimal screenshot Android app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# InkWrite
+# ScreenshotApp
+
+This repository contains a minimal Android application written in Kotlin that demonstrates how to capture the device screen using the MediaProjection API.
+
+The app requests screen capture permission on launch. After permission is granted, a foreground service captures a screenshot every 10 seconds and saves it under the app-specific external storage directory:
+
+```
+/storage/emulated/0/Android/data/com.example.screenshotapp/files/screenshots
+```
+
+Use the Start and Stop buttons on the main screen to control capturing. The capture state is preserved across configuration changes.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdkVersion 30
+
+    defaultConfig {
+        applicationId "com.example.screenshotapp"
+        minSdkVersion 26
+        targetSdkVersion 30
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.20"
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'com.google.android.material:material:1.3.0'
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules placeholder

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.screenshotapp">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+    <application
+        android:allowBackup="true"
+        android:label="ScreenshotApp"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <service
+            android:name=".ScreenshotService"
+            android:exported="false"/>
+    </application>
+</manifest>

--- a/app/src/main/java/com/example/screenshotapp/MainActivity.kt
+++ b/app/src/main/java/com/example/screenshotapp/MainActivity.kt
@@ -1,0 +1,80 @@
+package com.example.screenshotapp
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.media.projection.MediaProjectionManager
+import android.os.Bundle
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity() {
+
+    private var isCapturing = false
+    private lateinit var startButton: Button
+    private lateinit var stopButton: Button
+
+    private val mediaProjectionManager by lazy {
+        getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        startButton = findViewById(R.id.btnStart)
+        stopButton = findViewById(R.id.btnStop)
+
+        isCapturing = savedInstanceState?.getBoolean(KEY_IS_CAPTURING) ?: false
+        updateButtons()
+
+        startButton.setOnClickListener {
+            if (!isCapturing) {
+                val intent = mediaProjectionManager.createScreenCaptureIntent()
+                startActivityForResult(intent, REQUEST_SCREENSHOT)
+            }
+        }
+
+        stopButton.setOnClickListener {
+            stopCapture()
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == REQUEST_SCREENSHOT && resultCode == Activity.RESULT_OK) {
+            val serviceIntent = Intent(this, ScreenshotService::class.java).apply {
+                putExtra(ScreenshotService.EXTRA_RESULT_CODE, resultCode)
+                putExtra(ScreenshotService.EXTRA_RESULT_DATA, data)
+                action = ScreenshotService.ACTION_START
+            }
+            startForegroundService(serviceIntent)
+            isCapturing = true
+            updateButtons()
+        }
+    }
+
+    private fun stopCapture() {
+        val intent = Intent(this, ScreenshotService::class.java).apply {
+            action = ScreenshotService.ACTION_STOP
+        }
+        stopService(intent)
+        isCapturing = false
+        updateButtons()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(KEY_IS_CAPTURING, isCapturing)
+    }
+
+    private fun updateButtons() {
+        startButton.isEnabled = !isCapturing
+        stopButton.isEnabled = isCapturing
+    }
+
+    companion object {
+        private const val REQUEST_SCREENSHOT = 100
+        private const val KEY_IS_CAPTURING = "key_is_capturing"
+    }
+}

--- a/app/src/main/java/com/example/screenshotapp/ScreenshotService.kt
+++ b/app/src/main/java/com/example/screenshotapp/ScreenshotService.kt
@@ -1,0 +1,164 @@
+package com.example.screenshotapp
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.graphics.PixelFormat
+import android.hardware.display.DisplayManager
+import android.hardware.display.VirtualDisplay
+import android.media.ImageReader
+import android.media.projection.MediaProjection
+import android.media.projection.MediaProjectionManager
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.IBinder
+import android.util.DisplayMetrics
+import android.view.WindowManager
+import androidx.core.app.NotificationCompat
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.ByteBuffer
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class ScreenshotService : Service() {
+
+    private var mediaProjection: MediaProjection? = null
+    private var virtualDisplay: VirtualDisplay? = null
+    private var imageReader: ImageReader? = null
+
+    private var handlerThread: HandlerThread? = null
+    private var handler: Handler? = null
+    private var takingScreenshots = false
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> {
+                val resultCode = intent.getIntExtra(EXTRA_RESULT_CODE, Activity.RESULT_CANCELED)
+                val data = intent.getParcelableExtra<Intent>(EXTRA_RESULT_DATA)
+                startCapture(resultCode, data)
+            }
+            ACTION_STOP -> stopCapture()
+        }
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        stopCapture()
+        super.onDestroy()
+    }
+
+    private fun startCapture(resultCode: Int, data: Intent?) {
+        if (takingScreenshots) return
+        val manager = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+        mediaProjection = manager.getMediaProjection(resultCode, data!!)
+        setupVirtualDisplay()
+        startForeground(NOTIFICATION_ID, createNotification())
+        takingScreenshots = true
+        handlerThread = HandlerThread("ScreenshotThread").apply { start() }
+        handler = Handler(handlerThread!!.looper)
+        handler?.post(screenshotRunnable)
+    }
+
+    private fun stopCapture() {
+        if (!takingScreenshots) return
+        takingScreenshots = false
+        handler?.removeCallbacksAndMessages(null)
+        handlerThread?.quitSafely()
+        virtualDisplay?.release()
+        imageReader?.close()
+        mediaProjection?.stop()
+        stopForeground(true)
+        stopSelf()
+    }
+
+    private val screenshotRunnable = object : Runnable {
+        override fun run() {
+            if (!takingScreenshots) return
+            captureScreenshot()
+            handler?.postDelayed(this, INTERVAL_MS)
+        }
+    }
+
+    private fun setupVirtualDisplay() {
+        val metrics = DisplayMetrics()
+        val windowManager = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            display?.apply { getRealMetrics(metrics) }
+        } else {
+            @Suppress("DEPRECATION")
+            windowManager.defaultDisplay.getRealMetrics(metrics)
+        }
+        imageReader = ImageReader.newInstance(metrics.widthPixels, metrics.heightPixels, PixelFormat.RGBA_8888, 2)
+        virtualDisplay = mediaProjection?.createVirtualDisplay(
+            "ScreenCapture",
+            metrics.widthPixels,
+            metrics.heightPixels,
+            metrics.densityDpi,
+            DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+            imageReader?.surface,
+            null,
+            handler
+        )
+    }
+
+    private fun captureScreenshot() {
+        val reader = imageReader ?: return
+        val image = reader.acquireLatestImage() ?: return
+        val planes = image.planes
+        val buffer: ByteBuffer = planes[0].buffer
+        val pixelStride = planes[0].pixelStride
+        val rowStride = planes[0].rowStride
+        val rowPadding = rowStride - pixelStride * image.width
+        val bitmap = android.graphics.Bitmap.createBitmap(
+            image.width + rowPadding / pixelStride,
+            image.height,
+            android.graphics.Bitmap.Config.ARGB_8888
+        )
+        bitmap.copyPixelsFromBuffer(buffer)
+        image.close()
+        saveBitmap(bitmap)
+        bitmap.recycle()
+    }
+
+    private fun saveBitmap(bitmap: android.graphics.Bitmap) {
+        val dir = File(getExternalFilesDir("screenshots"), "")
+        if (!dir.exists()) dir.mkdirs()
+        val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+        val file = File(dir, "screenshot_${timestamp}.png")
+        FileOutputStream(file).use { out ->
+            bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, out)
+        }
+    }
+
+    private fun createNotification(): Notification {
+        val channelId = "screenshot_channel"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(channelId, "Screenshot", NotificationManager.IMPORTANCE_LOW)
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannel(channel)
+        }
+        return NotificationCompat.Builder(this, channelId)
+            .setContentTitle("Screenshot Service")
+            .setContentText("Capturing screen")
+            .setSmallIcon(android.R.drawable.ic_menu_camera)
+            .build()
+    }
+
+    companion object {
+        const val ACTION_START = "action_start"
+        const val ACTION_STOP = "action_stop"
+        const val EXTRA_RESULT_CODE = "extra_result_code"
+        const val EXTRA_RESULT_DATA = "extra_result_data"
+        const val INTERVAL_MS = 10_000L
+        const val NOTIFICATION_ID = 1
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/btnStart"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Start" />
+
+    <Button
+        android:id="@+id/btnStop"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Stop"
+        android:layout_marginTop="8dp" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">ScreenshotApp</string>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,3 @@
+<resources>
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar"/>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,19 @@
+buildscript {
+    ext.kotlin_version = "1.8.20"
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:8.0.0"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+include ':app'


### PR DESCRIPTION
## Summary
- initialize a basic Android project using Kotlin
- implement `MainActivity` with start/stop buttons and permission handling
- add `ScreenshotService` that captures the screen every 10 seconds via MediaProjection
- save screenshots to app-specific external storage
- configure Gradle build files and manifest

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68641f4befd48329bc3908481fb502b9